### PR TITLE
Add dash for command correctness

### DIFF
--- a/src/ws_material.md
+++ b/src/ws_material.md
@@ -12,9 +12,9 @@ Workshop materials
 
 Suggested version 8. (example openjdk version 1.8.0_181)
 
-`> etlas -version`
+`> etlas --version`
 
-`> eta -version`
+`> eta --version`
 
 
 ##  simple eta project


### PR DESCRIPTION
Thanks for the workshop

When following the instructions I think there is a missing dash when checking the versions

 ~  docker run -it typelead/eta                                                                                              ✔  337  19:50:13
root@9b72c453c048:/# etlas -version
etlas: unrecognised command: -version (try --help)
root@9b72c453c048:/# eta -version
eta: on the commandline: malformed integer argument in -version
Usage: For basic information, try the `--help' option.
root@9b72c453c048:/# etlas --version
etlas version 1.6.0.0
compiled using version 2.1.0.0 of the etlas-cabal library 
root@9b72c453c048:/# eta --version
The Eta Programming Language Compiler, Version 0.8.6b3, Git Revision ec199acc5b57b865b0a211efa1033e73ff5289d3
root@9b72c453c048:/# 
